### PR TITLE
Fix generation endpoint signature and implement stale job cleanup

### DIFF
--- a/api/src/main/java/mz/org/csaude/hl7sync/controller/ApiController.java
+++ b/api/src/main/java/mz/org/csaude/hl7sync/controller/ApiController.java
@@ -101,10 +101,8 @@ public class ApiController {
             return buildErrorResponse("District not found", "Unable to find a valid district in the child locations");
         }
 
-        // Check if there are health facilities
-        List<Location> healthFacilities = province.getChildLocations(); // Assuming same child locations
-        if (healthFacilities == null || healthFacilities.isEmpty()) {
-            return buildErrorResponse("Health facilities not found", "Unable to find any health facility for the provided locationUUID");
+        if (hl7FileForm.getHealthFacilities() == null || hl7FileForm.getHealthFacilities().isEmpty()) {
+            return buildErrorResponse("Facilities not found", "No health facilities were provided in the request");
         }
 
         // Create a new HL7 File Request
@@ -269,7 +267,7 @@ public class ApiController {
             return ResponseEntity.notFound().build();
         }
 
-        // Get only the last 3 jobs
+        // Get only the last job
         int startIndex = Math.max(0, jobs.size() - 1);
         List<Job> lastJobs = jobs.subList(startIndex, jobs.size());
 

--- a/api/src/main/java/mz/org/csaude/hl7sync/dao/jobrepository/JobRepositoryDao.java
+++ b/api/src/main/java/mz/org/csaude/hl7sync/dao/jobrepository/JobRepositoryDao.java
@@ -10,8 +10,7 @@ import java.util.Optional;
 @Repository
 public interface JobRepositoryDao extends JpaRepository<Job, Long> {
 
-    // Find a job by its location UUID and status
     List<Job> findByLocationUUIDAndStatusIn(String locationUUID, List<Job.JobStatus> statuses);
-    // Add this method to find a job by its jobId
     Optional<Job> findByJobId(String jobId);
+    List<Job> findByStatusIn(List<Job.JobStatus> statuses);
 }

--- a/api/src/main/java/mz/org/csaude/hl7sync/service/Hl7ServiceImpl.java
+++ b/api/src/main/java/mz/org/csaude/hl7sync/service/Hl7ServiceImpl.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -55,8 +54,6 @@ import mz.org.csaude.hl7sync.util.Hl7Util;
 public class Hl7ServiceImpl implements Hl7Service {
 
 	private static final String METADATA_JSON = ".metadata.json";
-
-	private static final String PROCESSING_PREFIX = ".";
 
 	private static final String HL7_EXTENSION = ".hl7.enc";
 
@@ -115,35 +112,6 @@ public class Hl7ServiceImpl implements Hl7Service {
 				log.error(String.format("Could not create folder %s", hl7FolderName), e);
 			}
 		}
-
-
-		//TODO - Implement logic to handle deletion of files
-//		// Check if there is a previous processing file
-//		Path processing = Paths.get(path.toString(), PROCESSING_PREFIX + hl7FileName + HL7_EXTENSION);
-//		Path done = Paths.get(path.toString(), hl7FileName + HL7_EXTENSION);
-//		// If there is a previously processed file, delete the temporary file because
-//		// the previous execution did not finish.
-//		if (Files.exists(done)) {
-//			// load serialized HL7File
-//			HL7File hl7File = new HL7File();
-//			Path serializePath = Paths.get(hl7FolderName, METADATA_JSON);
-//			if (Files.exists(serializePath)) {
-//				hl7File = objectMapper.readValue(Files.newInputStream(serializePath), HL7File.class);
-//			} else {
-//				hl7File.setLastModifiedTime(getFileLastModifiedTime());
-//			}
-//			ProcessingResult result = new ProcessingResult();
-//			result.setHl7File(hl7File);
-//			result.setErrorLogs(Collections.emptyList());
-//			processingResult = CompletableFuture.completedFuture(result);
-//			previousProcessingResult = result;
-//			if (Files.exists(processing))
-//				Files.delete(processing);
-//		} else if (Files.exists(processing)) {
-//			Files.delete(processing);
-//			processingResult = new CompletableFuture<>();
-//			processingResult.completeExceptionally(new AppException("Previous HL7 file generation did not finish."));
-//		}
 	}
 
 	@Override
@@ -184,7 +152,6 @@ public class Hl7ServiceImpl implements Hl7Service {
 		Path filePath = Paths.get(newJob.getDownloadURL());
 
 		try {
-
 			processingResult = new CompletableFuture<>();
 
 			List<String> errorLogs = createHl7File(hl7FileRequest, filePath);

--- a/api/src/main/java/mz/org/csaude/hl7sync/service/JobService.java
+++ b/api/src/main/java/mz/org/csaude/hl7sync/service/JobService.java
@@ -7,8 +7,7 @@ import java.util.Optional;
 
 public interface JobService {
     Optional<Job> findJobById(String jobId);
-
     List<Job> findByLocationUUIDAndStatuses(String locationUUID, List<Job.JobStatus> statuses);
-
+    List<Job> findByStatuses(List<Job.JobStatus> statuses);
     Job save(Job job);
 }

--- a/api/src/main/java/mz/org/csaude/hl7sync/service/JobServiceImpl.java
+++ b/api/src/main/java/mz/org/csaude/hl7sync/service/JobServiceImpl.java
@@ -1,17 +1,48 @@
 package mz.org.csaude.hl7sync.service;
-
 import mz.org.csaude.hl7sync.dao.jobrepository.JobRepositoryDao;
 import mz.org.csaude.hl7sync.model.Job;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class JobServiceImpl implements JobService{
 
+    private static final Logger log = LoggerFactory.getLogger(JobServiceImpl.class.getName());
+
     private final JobRepositoryDao jobRepositoryDao;
+
+    @PostConstruct
+    public void cleanupStaleJobsOnStartup() {
+        log.info("Checking for stale jobs on startup...");
+        List<Job.JobStatus> staleStatuses = List.of(Job.JobStatus.QUEUED, Job.JobStatus.PROCESSING);
+        List<Job> staleJobs = findByStatuses(staleStatuses);
+
+        if (staleJobs.isEmpty()) {
+            log.info("No stale jobs found.");
+            return;
+        }
+
+        log.warn("Found {} stale jobs. Marking as FAILED...", staleJobs.size());
+        for (Job job : staleJobs) {
+            job.setStatus(Job.JobStatus.FAILED);
+            job.setUpdatedAt(LocalDateTime.now());
+            job.setErrorDetails("Job failed due to an unexpected server restart or shutdown.");
+            save(job);
+        }
+        log.info("Stale job cleanup complete.");
+    }
+
+    @Override
+    public List<Job> findByStatuses(List<Job.JobStatus> statuses) {
+        return jobRepositoryDao.findByStatusIn(statuses);
+    }
 
     @Autowired
     public JobServiceImpl(JobRepositoryDao jobRepositoryDao) {

--- a/api/src/main/java/mz/org/csaude/hl7sync/service/LocationServiceImpl.java
+++ b/api/src/main/java/mz/org/csaude/hl7sync/service/LocationServiceImpl.java
@@ -39,7 +39,6 @@ public class LocationServiceImpl implements LocationService {
             @Value("${openmrs.password}") String password) {
 
         log.info(baseUrl);
-        log.info("HERE!");
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseUrl)
                 .pathSegment("ws", "rest", "v1");


### PR DESCRIPTION
# Summary

This PR introduces a self-healing mechanism to handle jobs that are stuck in a PROCESSING state due to unexpected server shutdowns.

# Key Changes
1. **Job Resilience (`JobServiceImpl.java`, `JobRepositoryDao.java`)**

    - **Startup Cleanup:** Added a `@PostConstruct` method, `cleanupStaleJobsOnStartup()`.

    - **Logic:** When the application starts, it now checks for any jobs remaining in `QUEUED` or `PROCESSING` states (orphaned by a previous crash/restart) and marks them as `FAILED`. This prevents the system from permanently blocking new requests for those locations.

# Ticket / Issue References

- Fixes client-server URL mismatch.
- Addresses "Job stuck in Processing" issue after server restarts.
- Supports "Server Unavailable" feedback feature on the frontend.

# How to Test
- **Stale Jobs:**
    - Trigger a long-running job.
    - Kill the server process immediately.
    - Restart the server.
    - Check the database; the interrupted job should now be marked as `FAILED`.